### PR TITLE
extend settings for auto-create and apply to complete vault

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -1,11 +1,15 @@
-import { App, DropdownComponent, MarkdownView, Plugin, PluginSettingTab, Setting} from 'obsidian';
+import { App, DropdownComponent, MarkdownView, Plugin, PluginSettingTab, Setting, ToggleComponent, getFrontMatterInfo} from 'obsidian';
 
 interface CounterSettings {
 	folders: string[];
+	autoCreate: boolean;
+	allFolders: boolean;
 }
 
 const DEFAULT_SETTINGS: CounterSettings = {
-	folders: []
+	folders: [],
+	autoCreate: false,
+	allFolders: false
 }
 
 export default class ObsidianCounter extends Plugin {
@@ -21,20 +25,24 @@ export default class ObsidianCounter extends Plugin {
 				if (view && view instanceof MarkdownView) {
 					// @ts-ignore
 					const isDirectoryIgnored = !this.settings.folders.includes(view.file.parent.path)
-					if (isDirectoryIgnored) {
+					if (!this.settings.allFolders && isDirectoryIgnored) {
 						return
 					}
 					// get yaml frontmatter
 					const file: any = view.file;
 					const content = await readFile(file);
-					const lines = getYamlFrontMatter(content)
-					if (!lines) {
-						return
-					}
-					// get visited property
-					const visitedProperty = getVisitedProperty(lines)
-					if (!visitedProperty) {
-						return
+					let lines = getYamlFrontMatter(content)
+					let visitedProperty;
+					if (lines) {
+						visitedProperty = getVisitedProperty(lines)
+					} 
+					// create property if set to autocreate
+					if (!visitedProperty && this.settings.autoCreate) {
+						if (!lines) {
+								lines = []
+						}
+						visitedProperty = 'visited: 0'
+						lines.push(visitedProperty)
 					}
 					let visitedValue: any = getPropertyValue(visitedProperty)
 					const visitedPropertyIndex = lines.indexOf(visitedProperty)
@@ -42,7 +50,8 @@ export default class ObsidianCounter extends Plugin {
 					visitedValue = Number(visitedValue) + 1
 					lines[visitedPropertyIndex] = formProperty('visited', visitedValue)
 					const updatedFrontMatter = convertArrayToYamlFrontMatter(lines)
-					await this.app.vault.modify(file, uniteFrontMatterAndContent(updatedFrontMatter, content))
+					const newContent = uniteFrontMatterAndContent(updatedFrontMatter, content)
+					await this.app.vault.modify(file, newContent)
 				}
 			})
 		);
@@ -66,11 +75,7 @@ export default class ObsidianCounter extends Plugin {
 	}
 }
 const getYamlFrontMatter = (content: string) => {
-	const blocks = content.split('---').slice(1, -1);
-	if (blocks.length === 0) {
-		return null
-	}
-	return blocks[0].split('\n').filter(Boolean);
+	return getFrontMatterInfo(content).frontmatter.split('\n').filter(Boolean);
 }
 const getVisitedProperty = (lines: any[]) => {
 	const visitedProperty: any = lines.find((property) => property.includes('visited'))
@@ -83,10 +88,17 @@ const formProperty = (propertyName: string, value: any) => {
 	return `${propertyName}: ${value}`
 }
 const convertArrayToYamlFrontMatter = (lines: any[]) => {
-	return '---\n' + lines.join('\n') + '\n---'
+	return lines.join('\n') + '\n'
 }
 const uniteFrontMatterAndContent = (frontMatter: string, content: string) => {
-	return `${frontMatter}${content.split('---')[2]}`
+	const frontMatterInfo = getFrontMatterInfo(content)
+	if (frontMatterInfo.exists) {
+		const contentBefore = content.substring(0, frontMatterInfo.from)
+		const contentAfter = content.substring(frontMatterInfo.to)
+		return String.prototype.concat(contentBefore, frontMatter, contentAfter)
+	} else {
+		return String.prototype.concat('---\n', frontMatter,'---\n', content)
+	}
 }
 
 class CounterSettingsTab extends PluginSettingTab {
@@ -113,7 +125,7 @@ class CounterSettingsTab extends PluginSettingTab {
 
 		this.selectedFolders = this.plugin.settings.folders || [];
 
-		new Setting(containerEl)
+		const selectedFoldersSetting = new Setting(containerEl)
 			.setName('Folders')
 			.setDesc('Select folders where the plugin should work')
 			.addTextArea(this.createTextArea());
@@ -121,7 +133,7 @@ class CounterSettingsTab extends PluginSettingTab {
 		const updateTextAreaField = this.createUpdateTextAreaHandler(containerEl);
 		const clearSelectionHandler = this.createClearSelectionHandler(updateTextAreaField);
 
-		new Setting(buttonContainer)
+		const selectedFoldersButtons = new Setting(buttonContainer)
 			.addButton(button => button.setButtonText('Clear Selection').onClick(clearSelectionHandler))
 			.addDropdown(dropdown => {
 				dropdown.addOption('', 'Select Folders');
@@ -130,6 +142,31 @@ class CounterSettingsTab extends PluginSettingTab {
 			});
 
 		containerEl.appendChild(buttonContainer);
+
+		new Setting(containerEl)
+			.setName('Use for all notes vault')
+			.setDesc('Toggles whether the plugin will be applied throughout every note in your vault')
+			.addToggle((toggle: ToggleComponent) => {
+				toggle.setValue(this.plugin.settings.allFolders)
+				toggle.onChange(async (value) => {
+					this.plugin.settings.allFolders = value
+					selectedFoldersButtons.setDisabled(value)
+					selectedFoldersSetting.setDisabled(value)
+					await this.plugin.saveSettings()
+				})
+			})
+
+		new Setting(containerEl)
+			.setName('Auto-create property')
+			.setDesc('Toggles whether the visited property is created automatically if not already existing')
+			.addToggle((toggle: ToggleComponent) => {
+				toggle.setValue(this.plugin.settings.autoCreate)
+				toggle.onChange(async (value) => {
+					this.plugin.settings.autoCreate = value
+					await this.plugin.saveSettings()
+					console.log("this", this)
+				})
+			})
 	}
 	getUniqueFolders() {
 		return [...new Set(this.app.vault.getFiles().map(file => file.parent.path))];


### PR DESCRIPTION
**1. I extended the settings**
  - auto create property (to create `visited` even if not existing)
  - apply to complete vault (to automatically apply functionality to complete vault)

    _Reason_: I want to use it as kind of heatmap for my whole vault, which notes are touched the most. I thought this might be a nice extension for the plugin too.

**2. Also I enhanced the parsing of the frontmatter too**
  -  instead of looking for the `---` string, I used the [FrontMatterInfo](https://docs.obsidian.md/Reference/TypeScript+API/FrontMatterInfo) from the obsidian api